### PR TITLE
add missing import for struct inside ecpri module

### DIFF
--- a/scapy/contrib/ecpri.py
+++ b/scapy/contrib/ecpri.py
@@ -15,6 +15,7 @@
 # scapy.contrib.description = enhanced Common Public Radio Interface (eCPRI)
 # scapy.contrib.status = loads
 
+import struct
 from scapy.packet import Packet, bind_layers, Padding
 from scapy.fields import (
     BitField, ByteField,


### PR DESCRIPTION
This is just a checklist to guide you. You can remove it safely.

**Checklist:**

-   [ ] If you are new to Scapy: I have checked <https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md> (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)

> brief description what this PR will do, e.g. fixes broken dissection of XXX

> if required - short explanation why you fixed something in a way that may look more complicated as it actually is

> if required - outline impacts on other parts of the library

fixes #xxx (add issue number here if appropriate, else remove this line)
